### PR TITLE
feat: add prisma setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
 coverage
+prisma/dev.db
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ Projeto inicial em Node.js com TypeScript.
 - `npm run fmt` – formata com Prettier.
 - `npm test` – roda os testes com Jest.
 - `npm run build` – gera a versão compilada em `dist/`.
+- `npm run prisma:generate` – gera o cliente Prisma.
+- `npm run prisma:migrate` – executa migrações do banco.
+- `npm run seed` – popula o banco com dados iniciais.
 
 ## Como rodar
 
 1. Instale as dependências com `npm ci`.
-2. Inicie o servidor em desenvolvimento com `npm run dev`.
-3. Rode os testes com `npm test`.
-4. Gere o build com `npm run build`.
-5. Execute o build com `npm start`.
+2. Gere o cliente com `npm run prisma:generate`.
+3. Rode as migrações com `npm run prisma:migrate`.
+4. Popule o banco com `npm run seed`.
+5. Inicie o servidor em desenvolvimento com `npm run dev`.
+6. Rode os testes com `npm test`.
+7. Gere o build com `npm run build`.
+8. Execute o build com `npm start`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^5.14.0",
         "express": "^5.1.0"
       },
       "devDependencies": {
+        "prisma": "^5.14.0",
         "supertest": "^7.1.4",
+        "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0"
       }
     },
@@ -78,6 +81,74 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1244,6 +1315,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,22 @@
     "lint": "npx --yes -p eslint@8 eslint . --ext .ts",
     "fmt": "npx --yes -p prettier prettier . --write",
     "test": "npm run build && npx --yes jest dist",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "seed": "ts-node prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "supertest": "^7.1.4",
-    "ts-node-dev": "^2.0.0"
+    "ts-node-dev": "^2.0.0",
+    "prisma": "^5.14.0",
+    "ts-node": "^10.9.2"
   },
   "dependencies": {
+    "@prisma/client": "^5.14.0",
     "express": "^5.1.0"
   }
 }

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable
+CREATE TABLE "User" (
+  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "name" TEXT NOT NULL,
+  "email" TEXT,
+  "phone" TEXT,
+  "apt" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'RESIDENT',
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateTable
+CREATE TABLE "Area" (
+  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "openHour" INTEGER NOT NULL,
+  "closeHour" INTEGER NOT NULL,
+  "slotMinutes" INTEGER NOT NULL,
+  "maxAdvanceDays" INTEGER NOT NULL,
+  "maxDurationMins" INTEGER NOT NULL,
+  "active" BOOLEAN NOT NULL DEFAULT 1
+);
+
+-- CreateTable
+CREATE TABLE "Reservation" (
+  "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  "areaId" INTEGER NOT NULL,
+  "userId" INTEGER,
+  "requesterName" TEXT NOT NULL,
+  "apt" TEXT NOT NULL,
+  "phone" TEXT NOT NULL,
+  "startAt" DATETIME NOT NULL,
+  "endAt" DATETIME NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'PENDING',
+  "purpose" TEXT,
+  "notes" TEXT,
+  "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY ("areaId") REFERENCES "Area" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "Reservation_areaId_idx" ON "Reservation"("areaId");
+
+-- CreateIndex
+CREATE INDEX "Reservation_userId_idx" ON "Reservation"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,61 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+enum Role {
+  ADMIN
+  RESIDENT
+}
+
+enum ReservationStatus {
+  PENDING
+  APPROVED
+  CANCELED
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String?
+  phone     String?
+  apt       String
+  role      Role     @default(RESIDENT)
+  createdAt DateTime @default(now())
+  reservations Reservation[]
+}
+
+model Area {
+  id             Int      @id @default(autoincrement())
+  name           String
+  description    String?
+  openHour       Int
+  closeHour      Int
+  slotMinutes    Int
+  maxAdvanceDays Int
+  maxDurationMins Int
+  active         Boolean  @default(true)
+  reservations   Reservation[]
+}
+
+model Reservation {
+  id            Int      @id @default(autoincrement())
+  area          Area     @relation(fields: [areaId], references: [id])
+  areaId        Int
+  user          User?    @relation(fields: [userId], references: [id])
+  userId        Int?
+  requesterName String
+  apt           String
+  phone         String
+  startAt       DateTime
+  endAt         DateTime
+  status        ReservationStatus @default(PENDING)
+  purpose       String?
+  notes         String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,36 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.area.createMany({
+    data: [
+      {
+        name: 'Salão de Festas',
+        openHour: 9,
+        closeHour: 22,
+        slotMinutes: 60,
+        maxAdvanceDays: 90,
+        maxDurationMins: 300,
+      },
+      {
+        name: 'Churrasqueira',
+        openHour: 9,
+        closeHour: 22,
+        slotMinutes: 60,
+        maxAdvanceDays: 90,
+        maxDurationMins: 300,
+      },
+    ],
+    skipDuplicates: true,
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- configure Prisma with SQLite schema and migrations
- seed default areas
- document database scripts and usage

## Testing
- `npm run prisma:generate` *(fails: Failed to fetch engine files - 403 Forbidden)*
- `npm run prisma:migrate` *(fails: Failed to fetch engine files - 403 Forbidden)*
- `npm run seed` *(fails: @prisma/client did not initialize yet. Please run "prisma generate" and try to import it again)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09b81539483299d249afcbb9d2207